### PR TITLE
fix memory leak

### DIFF
--- a/NSData+Seal.m
+++ b/NSData+Seal.m
@@ -150,7 +150,7 @@
 
     [options setObject:password forKey:(__bridge id)kSecImportExportPassphrase];
 
-    CFArrayRef items = CFArrayCreate(NULL, 0, 0, NULL);
+    CFArrayRef items = NULL;
 
     OSStatus securityError = SecPKCS12Import((__bridge CFDataRef)self, (CFDictionaryRef)CFBridgingRelease(options), &items);
 


### PR DESCRIPTION
CFArrayCreate would alloccate memory for items which leaks after
calling SecPKCS12Import
